### PR TITLE
Refactor TotNode entity for composite key support; improve ToT node s…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 ### Database Access
-- **Production**: MariaDB at `localhost:3306/tot` (username: `root`, password: `root`)
+- **Production**: MariaDB at `localhost:3306/tot` (username: `root`, password: `***`)
 - **H2 Console**: http://localhost:8080/h2-console (enabled for development)
 - **H2 Connection**: `jdbc:h2:mem:testdb` (username: `sa`, no password)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,23 @@ mvn clean package
 
 # Run tests
 mvn test
+
+# Run specific test class
+mvn test -Dtest=ClassName
+
+# Run with specific profile
+mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 ### Database Access
-- H2 Console: http://localhost:8080/h2-console
-- Default connection: `jdbc:h2:mem:testdb` (username: `sa`, no password)
+- **Production**: MariaDB at `localhost:3306/tot` (username: `root`, password: `root`)
+- **H2 Console**: http://localhost:8080/h2-console (enabled for development)
+- **H2 Connection**: `jdbc:h2:mem:testdb` (username: `sa`, no password)
 
 ### API Documentation
-- Swagger UI: http://localhost:8080/swagger-ui.html
-- Application runs on port 8080
+- **Swagger UI**: http://localhost:8080/swagger-ui.html
+- **OpenAPI Docs**: http://localhost:8080/v3/api-docs
+- **Application Port**: 8080
 
 ## Architecture Overview
 
@@ -62,6 +70,23 @@ This is a Tree of Thought (ToT) scheduling system that combines AI reasoning wit
 6. RefinementService updates tree based on results
 
 ### Configuration
-- Perplexity API key in `application.properties` (marked as ****)
-- Async processing enabled via `AsyncConfig`
-- All services use constructor injection with `@Autowired`
+- **Perplexity API**: Key configured in `application.properties` for LLM validation
+- **Stock Data API**: Finnhub API integration for real-time stock data validation
+- **Scheduler**: Cron expression `0 */5 * * * *` (every 5 minutes)
+- **Async Processing**: Enabled via `@EnableAsync` and `AsyncConfig`
+- **Database**: MariaDB in production, H2 for development/testing
+- **Debug Logging**: Enabled for `com.tot` package for troubleshooting
+
+### Key Technical Details
+- **Spring Boot 3.4.3** with Java-based configuration
+- **JPA/Hibernate** with automatic schema updates (`ddl-auto=update`)
+- **RESTful APIs** with OpenAPI 3.0 documentation
+- **Lombok** for boilerplate reduction
+- **WebFlux** for reactive programming support
+- **Constructor-based dependency injection** throughout
+
+### Testing Framework
+- **JUnit 5 (Jupiter)** for unit testing
+- **Mockito** for mocking dependencies
+- **AssertJ** for fluent assertions
+- No test files currently exist - consider adding test coverage

--- a/src/main/java/com/tot/controller/UserController.java
+++ b/src/main/java/com/tot/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.tot.controller;
 
-import com.tot.entity.TotNode;
 import com.tot.service.LLMService;
 import com.tot.service.TotService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -193,32 +192,33 @@ public class UserController {
     }
 
     @PostMapping("/save")
-    @Operation(summary = "Save ToT", description = "Save the Tree of Thought structure into the database")
+    @Operation(summary = "Save ToT", description = "Create a new independent Tree of Thought with the provided treeId")
     public ResponseEntity<String> saveTot(@RequestParam String treeId, @RequestBody String treeJson) {
-        logger.info("Received request to save ToT for treeId: {}", treeId);
+        logger.info("Received request to create new independent ToT with treeId: {}", treeId);
 
         try {
             // Parse the JSON into a list of node objects
             List<Map<String, Object>> nodeList = objectMapper.readValue(
                     treeJson, new com.fasterxml.jackson.core.type.TypeReference<List<Map<String, Object>>>() {});
 
-            // Update each node's treeId to the provided treeId
+            // Create new independent tree - ignore any treeId in JSON, use parameter treeId for all nodes
             for (Map<String, Object> nodeMap : nodeList) {
+                // Always use the parameter treeId, ignore any treeId in the JSON
                 nodeMap.put("treeId", treeId);
             }
 
             // Convert updated nodeList back to JSON string
             String updatedTreeJson = objectMapper.writeValueAsString(nodeList);
 
-            // Save the updated tree JSON using TotService and get the treeId
+            // Save the new tree JSON using TotService
             String savedTreeId = totService.saveTreeOfThought(updatedTreeJson);
 
-            // Return the treeId and info about saved tree
-            String response = String.format("Updated and saved ToT with treeId: %s", savedTreeId);
+            // Return success message
+            String response = String.format("Successfully created new independent ToT with treeId: %s", savedTreeId);
             return ResponseEntity.ok(response);
         } catch (Exception e) {
-            logger.error("Error saving ToT: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError().body("Error saving ToT: " + e.getMessage());
+            logger.error("Error creating new ToT: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().body("Error creating new ToT: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/tot/entity/TotNode.java
+++ b/src/main/java/com/tot/entity/TotNode.java
@@ -5,23 +5,51 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 @Entity
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
+@IdClass(TotNode.TotNodeId.class)
 public class TotNode {
     @Id
     private String nodeId;
-
+    
+    @Id
     private String treeId;
+
     private String content;  // Content of the node (e.g., description/details)
     private String criteria;   // Prompt used for LLM evaluation
 
     @ElementCollection
-    @CollectionTable(name = "node_children", joinColumns = @JoinColumn(name = "node_id"))
+    @CollectionTable(name = "node_children", 
+                     joinColumns = {
+                         @JoinColumn(name = "node_id", referencedColumnName = "nodeId"),
+                         @JoinColumn(name = "tree_id", referencedColumnName = "treeId")
+                     })
     @MapKeyColumn(name = "branch_key")
     @Column(name = "child_node_id")
     private Map<String, String> children; // Mapping of branch keys (e.g., "yes", "no") to child nodeIds
+
+    @Data
+    @NoArgsConstructor
+    public static class TotNodeId implements Serializable {
+        private String nodeId;
+        private String treeId;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TotNodeId totNodeId = (TotNodeId) o;
+            return Objects.equals(nodeId, totNodeId.nodeId) && Objects.equals(treeId, totNodeId.treeId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nodeId, treeId);
+        }
+    }
 }

--- a/src/main/java/com/tot/service/TotService.java
+++ b/src/main/java/com/tot/service/TotService.java
@@ -89,7 +89,8 @@ public class TotService {
         try {
             // Parse the JSON into a list of node objects
             List<Map<String, Object>> nodeList = objectMapper.readValue(
-                    treeJson, new TypeReference<List<Map<String, Object>>>() {});
+                    treeJson, new TypeReference<>() {
+                    });
 
             List<TotNode> savedNodes = new ArrayList<>();
 
@@ -97,11 +98,21 @@ public class TotService {
             for (Map<String, Object> nodeMap : nodeList) {
                 TotNode node = new TotNode();
 
-                // Set basic properties
-                node.setNodeId((String) nodeMap.get("nodeId"));
-                node.setTreeId((String) nodeMap.get("treeId"));
-                node.setContent((String) nodeMap.get("content"));
-                node.setCriteria((String) nodeMap.get("criteria"));
+                // Explicitly set properties using JSON key names to avoid field order dependency
+                String nodeId = (String) nodeMap.get("nodeId");
+                String treeId = (String) nodeMap.get("treeId");
+                String content = (String) nodeMap.get("content");
+                String criteria = (String) nodeMap.get("criteria");
+                
+                // Log the values being set for debugging
+                logger.debug("Setting node - nodeId: {}, treeId: {}, content: {}, criteria: {}", 
+                            nodeId, treeId, content, criteria);
+                
+                // Set properties explicitly
+                node.setNodeId(nodeId);
+                node.setTreeId(treeId);
+                node.setContent(content);
+                node.setCriteria(criteria);
 
                 // Handle children map
                 @SuppressWarnings("unchecked")
@@ -114,7 +125,8 @@ public class TotService {
                 // Save node to repository
                 TotNode savedNode = totNodeRepository.save(node);
                 savedNodes.add(savedNode);
-                logger.debug("Saved node: nodeId={}, treeId={}", savedNode.getNodeId(), savedNode.getTreeId());
+                logger.debug("Saved node: nodeId={}, treeId={}, content={}", 
+                            savedNode.getNodeId(), savedNode.getTreeId(), savedNode.getContent());
             }
 
             logger.info("Saved {} nodes for Tree of Thought", savedNodes.size());


### PR DESCRIPTION
…aving logs; restrict treeId usage in ToT creation; enhance stock data logging; update CLAUDE.md with environment and tech details

- Add composite primary key (nodeId, treeId) to TotNode with IdClass for JPA mapping and correct children collection joins
- In TotService, explicitly set TotNode properties from JSON keys to avoid field order issues and add debug logs for node property values and saved nodes
- In UserController’s /save endpoint, enforce use of request parameter treeId for all nodes, ignoring any treeId in JSON to ensure creation of independent ToTs; clarify log messages and responses accordingly
- In StockDataService, filter and log only the “metric” portion of API responses to reduce noise; add fallback logging on parse failures
- Update CLAUDE.md to document project environment details, API endpoints, configuration keys, technical stack, and testing framework notes for developer reference